### PR TITLE
Refactor evaluation output structure: separate assertions from metric…

### DIFF
--- a/.test-temp/suggest-suite-1763534743919/output/test.ts
+++ b/.test-temp/suggest-suite-1763534743919/output/test.ts
@@ -1,0 +1,1 @@
+content

--- a/examples/testcase-basic.yaml
+++ b/examples/testcase-basic.yaml
@@ -49,7 +49,7 @@ evaluators:
         # Useful when you want focused, single-purpose changes
         max_change_entropy: 2.0
 
-  - name: agentic-judge
+  - name: agentic-judge:basic
     config:
       type: copilot-cli
       # Optional: Set timeout in milliseconds (default: 300000 = 5 minutes)

--- a/src/evaluators/agentic-judge.ts
+++ b/src/evaluators/agentic-judge.ts
@@ -184,17 +184,25 @@ export class AgenticJudgeEvaluator implements Evaluator {
       const completedAt = new Date().toISOString();
       const durationMs = new Date(completedAt).getTime() - new Date(startedAt).getTime();
 
+      // Separate assertion results from other metrics
+      // evaluationOutput.metrics contains the assertion scores (e.g., readme_modified: 1)
+      // We need to move those to the assertions field at top level
+      const assertionResults = { ...evaluationOutput.metrics };
+      
+      // Keep only non-assertion metadata in metrics
+      const metadataMetrics = {
+        agent_type: agentType,
+        agent_duration_ms: agentResult.durationMs,
+      };
+
       return {
         evaluator: this.name,
         status: evaluationOutput.status,
-        metrics: {
-          ...evaluationOutput.metrics,
-          agent_type: agentType,
-          agent_duration_ms: agentResult.durationMs,
-        },
+        metrics: metadataMetrics,
         message: evaluationOutput.message,
         duration_ms: durationMs,
         timestamp: completedAt,
+        assertions: assertionResults as Record<string, unknown>,
       };
     } catch (error) {
       const completedAt = new Date().toISOString();

--- a/src/evaluators/expected-diff.ts
+++ b/src/evaluators/expected-diff.ts
@@ -107,7 +107,6 @@ export class ExpectedDiffEvaluator implements Evaluator {
         status,
         metrics: {
           aggregate_similarity: metrics.aggregate_similarity,
-          threshold,
           files_matched: metrics.files_matched,
           files_changed: metrics.files_changed,
           files_added: metrics.files_added,
@@ -117,6 +116,9 @@ export class ExpectedDiffEvaluator implements Evaluator {
         message,
         duration_ms: durationMs,
         timestamp: completedAt,
+        assertions: {
+          threshold,
+        },
         artifacts,
       };
     } catch (error) {

--- a/src/evaluators/git-diff.ts
+++ b/src/evaluators/git-diff.ts
@@ -144,20 +144,20 @@ export class GitDiffEvaluator implements Evaluator {
           changed_files: fileMetrics,
           base_commit: baseCommit,
           current_commit: currentCommit,
-          // Include assertions in metrics for transparency
-          assertions: config.assertions ? {
-            max_files_changed: config.assertions.max_files_changed,
-            max_lines_added: config.assertions.max_lines_added,
-            max_lines_removed: config.assertions.max_lines_removed,
-            max_total_changes: config.assertions.max_total_changes,
-            min_change_entropy: config.assertions.min_change_entropy,
-            max_change_entropy: config.assertions.max_change_entropy,
-          } : undefined,
           violations: violations.length > 0 ? violations : undefined,
         },
         message,
         duration_ms: durationMs,
         timestamp: completedAt,
+        // Include assertions at top level for transparency
+        assertions: config.assertions ? {
+          max_files_changed: config.assertions.max_files_changed,
+          max_lines_added: config.assertions.max_lines_added,
+          max_lines_removed: config.assertions.max_lines_removed,
+          max_total_changes: config.assertions.max_total_changes,
+          min_change_entropy: config.assertions.min_change_entropy,
+          max_change_entropy: config.assertions.max_change_entropy,
+        } : undefined,
         artifacts,
       };
     } catch (error) {

--- a/src/schemas/result.schema.ts
+++ b/src/schemas/result.schema.ts
@@ -34,6 +34,7 @@ export const evaluationResultSchema = z.object({
   message: z.string(),
   duration_ms: z.number().nonnegative(),
   timestamp: z.string(), // ISO 8601 format
+  assertions: z.record(z.any()).optional(), // Configured assertions/thresholds for this evaluator
   artifacts: z.array(artifactSchema).optional(),
   error: evaluationErrorSchema.optional(),
 });

--- a/tests/contract/results.test.ts
+++ b/tests/contract/results.test.ts
@@ -148,7 +148,9 @@ describe('Results Bundle Schema Contract', () => {
     it('should validate a complete results bundle', () => {
       const validBundle: ResultsBundle = {
         version: '1.0.0',
-        suite: {
+        test_case: {
+          name: 'Test Case Name',
+          description: 'Test case description',
           config_file: 'suite.yaml',
           config_hash: 'abc123def456',
           repo: 'https://github.com/example/test-repo',
@@ -218,7 +220,9 @@ describe('Results Bundle Schema Contract', () => {
     it('should validate bundle with partial success', () => {
       const bundle: ResultsBundle = {
         version: '1.0.0',
-        suite: {
+        test_case: {
+          name: 'Partial Success Test',
+          description: 'Test with partial success',
           config_file: 'suite.yaml',
           config_hash: 'abc123',
           repo: 'https://github.com/example/test-repo',
@@ -284,7 +288,9 @@ describe('Results Bundle Schema Contract', () => {
     it('should validate bundle with failed evaluations', () => {
       const bundle: ResultsBundle = {
         version: '1.0.0',
-        suite: {
+        test_case: {
+          name: 'Failed Evaluation Test',
+          description: 'Test with failed evaluations',
           config_file: 'suite.yaml',
           config_hash: 'abc123',
           repo: 'https://github.com/example/test-repo',
@@ -340,7 +346,9 @@ describe('Results Bundle Schema Contract', () => {
   describe('Invalid Results Bundle', () => {
     it('should reject bundle without version', () => {
       const invalidBundle = {
-        suite: {
+        test_case: {
+          name: 'Test',
+          description: 'Test description',
           config_file: 'suite.yaml',
           config_hash: 'abc123',
           repo: 'https://github.com/example/test-repo',
@@ -386,7 +394,9 @@ describe('Results Bundle Schema Contract', () => {
     it('should reject bundle with invalid version', () => {
       const invalidBundle = {
         version: '2.0.0', // Invalid version
-        suite: {
+        test_case: {
+          name: 'Test',
+          description: 'Test description',
           config_file: 'suite.yaml',
           config_hash: 'abc123',
           repo: 'https://github.com/example/test-repo',
@@ -432,7 +442,9 @@ describe('Results Bundle Schema Contract', () => {
     it('should reject bundle with invalid overall_status', () => {
       const invalidBundle = {
         version: '1.0.0',
-        suite: {
+        test_case: {
+          name: 'Test',
+          description: 'Test description',
           config_file: 'suite.yaml',
           config_hash: 'abc123',
           repo: 'https://github.com/example/test-repo',

--- a/tests/unit/expected-diff.test.ts
+++ b/tests/unit/expected-diff.test.ts
@@ -352,7 +352,7 @@ describe('ExpectedDiffEvaluator', () => {
       const result = await evaluator.evaluate(context);
 
       expect(result.status).toBe('passed');
-      expect(result.metrics.threshold).toBe(0.95);
+      expect(result.assertions.threshold).toBe(0.95);
       expect(result.metrics.aggregate_similarity).toBeGreaterThanOrEqual(0.95);
     });
 
@@ -373,7 +373,7 @@ describe('ExpectedDiffEvaluator', () => {
       const result = await evaluator.evaluate(context);
 
       expect(result.status).toBe('failed');
-      expect(result.metrics.threshold).toBe(0.80);
+      expect(result.assertions.threshold).toBe(0.80);
       expect(result.metrics.aggregate_similarity).toBeLessThan(0.80);
     });
 
@@ -392,7 +392,7 @@ describe('ExpectedDiffEvaluator', () => {
 
       const result = await evaluator.evaluate(context);
 
-      expect(result.metrics.threshold).toBe(0.80);
+      expect(result.assertions.threshold).toBe(0.80);
     });
   });
 
@@ -541,7 +541,7 @@ describe('ExpectedDiffEvaluator', () => {
       const result = await evaluator.evaluate(context);
 
       expect(result.metrics).toHaveProperty('aggregate_similarity');
-      expect(result.metrics).toHaveProperty('threshold');
+      expect(result.assertions).toHaveProperty('threshold');
       expect(result.metrics).toHaveProperty('files_matched');
       expect(result.metrics).toHaveProperty('files_changed');
       expect(result.metrics).toHaveProperty('files_added');

--- a/tests/unit/git-diff.test.ts
+++ b/tests/unit/git-diff.test.ts
@@ -322,9 +322,9 @@ describe('GitDiffEvaluator', () => {
 
       const result = await evaluator.evaluate(context);
       
-      expect(result.metrics.assertions).toBeDefined();
-      expect(result.metrics.assertions.max_files_changed).toBe(5);
-      expect(result.metrics.assertions.max_lines_added).toBe(100);
+      expect(result.assertions).toBeDefined();
+      expect(result.assertions.max_files_changed).toBe(5);
+      expect(result.assertions.max_lines_added).toBe(100);
     });
 
     it('should include violations in message when failed', async () => {


### PR DESCRIPTION
This pull request refactors how assertion and threshold values are reported in evaluator results, improving clarity and schema consistency. Assertions are now separated from general metrics and placed at the top level of evaluator outputs. The results schema and related tests have been updated to reflect this change, ensuring more accurate validation and usage of evaluation results.

**Evaluator Output Refactoring:**

* Evaluator classes (`AgenticJudgeEvaluator`, `ExpectedDiffEvaluator`, `GitDiffEvaluator`) now return assertion and threshold values in a new top-level `assertions` field, separating them from general metrics for clearer reporting. [[1]](diffhunk://#diff-c6d7137be74b296981c4bc0a8562fc1fea565048cb4e4b5d9bcc356b67a49e8bR187-R205) [[2]](diffhunk://#diff-0b4718468fae33a06ce7da6e4f95b392cb853ca4fa1b833ec69f985af147cdf4R119-R121) [[3]](diffhunk://#diff-21d1ae93b31f6189f2ce056ec59e58d51823a04c8514265de5c10dc755e25dddL147-R152) [[4]](diffhunk://#diff-21d1ae93b31f6189f2ce056ec59e58d51823a04c8514265de5c10dc755e25dddL156-L160)

**Schema and Contract Updates:**

* The `evaluationResultSchema` in `src/schemas/result.schema.ts` has been updated to include an optional top-level `assertions` field, supporting the new output structure.
* Contract tests in `tests/contract/results.test.ts` updated to expect a `test_case` field instead of `suite`, reflecting schema changes and ensuring correct validation. [[1]](diffhunk://#diff-e250eb1a991129841f90bbcc5b3bda0487825a0b570b0abf9d89a50b01784cd2L151-R153) [[2]](diffhunk://#diff-e250eb1a991129841f90bbcc5b3bda0487825a0b570b0abf9d89a50b01784cd2L221-R225) [[3]](diffhunk://#diff-e250eb1a991129841f90bbcc5b3bda0487825a0b570b0abf9d89a50b01784cd2L287-R293) [[4]](diffhunk://#diff-e250eb1a991129841f90bbcc5b3bda0487825a0b570b0abf9d89a50b01784cd2L343-R351) [[5]](diffhunk://#diff-e250eb1a991129841f90bbcc5b3bda0487825a0b570b0abf9d89a50b01784cd2L389-R399) [[6]](diffhunk://#diff-e250eb1a991129841f90bbcc5b3bda0487825a0b570b0abf9d89a50b01784cd2L435-R447)

**Unit Test Adjustments:**

* Unit tests for `ExpectedDiffEvaluator` and `GitDiffEvaluator` updated to check assertion values in the new `assertions` field, ensuring tests align with refactored output. [[1]](diffhunk://#diff-c6e709fe0267b3f62149f21cb180dbd6b32d4508ca236a6e90029f6d38065e5dL355-R355) [[2]](diffhunk://#diff-c6e709fe0267b3f62149f21cb180dbd6b32d4508ca236a6e90029f6d38065e5dL376-R376) [[3]](diffhunk://#diff-c6e709fe0267b3f62149f21cb180dbd6b32d4508ca236a6e90029f6d38065e5dL395-R395) [[4]](diffhunk://#diff-c6e709fe0267b3f62149f21cb180dbd6b32d4508ca236a6e90029f6d38065e5dL544-R544) [[5]](diffhunk://#diff-1f7cf75f22114e03252b276c47aa838e02a4dc387ffe703aa8d7cba36f2db9a3L325-R327)

**Configuration Update:**

* The evaluator name in `examples/testcase-basic.yaml` changed from `agentic-judge` to `agentic-judge:basic` for improved clarity and specificity.

**Miscellaneous:**

* Adds a placeholder file `.test-temp/suggest-suite-1763534743919/output/test.ts` for testing output.…s and update related tests